### PR TITLE
Support GitLab math syntax:

### DIFF
--- a/bin/hoedown.c
+++ b/bin/hoedown.c
@@ -40,6 +40,7 @@ static struct extension_category_info categories_info[] = {
 static struct extension_info extensions_info[] = {
 	{HOEDOWN_EXT_TABLES, "tables", "Parse PHP-Markdown style tables."},
 	{HOEDOWN_EXT_FENCED_CODE, "fenced-code", "Parse fenced code blocks."},
+	{HOEDOWN_EXT_FENCED_MATH|HOEDOWN_EXT_FENCED_CODE, "fenced-math", "Parse fenced math blocks."},
 	{HOEDOWN_EXT_FOOTNOTES, "footnotes", "Parse footnotes."},
 
 	{HOEDOWN_EXT_AUTOLINK, "autolink", "Automatically turn safe URLs into links."},
@@ -49,6 +50,7 @@ static struct extension_info extensions_info[] = {
 	{HOEDOWN_EXT_QUOTE, "quote", "Render \"quotes\" as <q>quotes</q>."},
 	{HOEDOWN_EXT_SUPERSCRIPT, "superscript", "Parse super^script."},
 	{HOEDOWN_EXT_MATH, "math", "Parse TeX $$math$$ syntax, Kramdown style."},
+	{HOEDOWN_EXT_MATH_BACKTICK|HOEDOWN_EXT_MATH, "backtick-math", "Parse $`math`$ syntax."},
 
 	{HOEDOWN_EXT_NO_INTRA_EMPHASIS, "disable-intra-emphasis", "Disable emphasis_between_words."},
 	{HOEDOWN_EXT_SPACE_HEADERS, "space-headers", "Require a space after '#' in headers."},

--- a/src/document.h
+++ b/src/document.h
@@ -20,6 +20,7 @@ typedef enum hoedown_extensions {
 	HOEDOWN_EXT_TABLES = (1 << 0),
 	HOEDOWN_EXT_FENCED_CODE = (1 << 1),
 	HOEDOWN_EXT_FOOTNOTES = (1 << 2),
+	HOEDOWN_EXT_FENCED_MATH = (1 << 15),
 
 	/* span-level extensions */
 	HOEDOWN_EXT_AUTOLINK = (1 << 3),
@@ -29,6 +30,7 @@ typedef enum hoedown_extensions {
 	HOEDOWN_EXT_QUOTE = (1 << 7),
 	HOEDOWN_EXT_SUPERSCRIPT = (1 << 8),
 	HOEDOWN_EXT_MATH = (1 << 9),
+	HOEDOWN_EXT_MATH_BACKTICK = (1 << 16),
 
 	/* other flags */
 	HOEDOWN_EXT_NO_INTRA_EMPHASIS = (1 << 11),
@@ -42,7 +44,8 @@ typedef enum hoedown_extensions {
 #define HOEDOWN_EXT_BLOCK (\
 	HOEDOWN_EXT_TABLES |\
 	HOEDOWN_EXT_FENCED_CODE |\
-	HOEDOWN_EXT_FOOTNOTES )
+	HOEDOWN_EXT_FENCED_MATH |\
+	HOEDOWN_EXT_FOOTNOTES)
 
 #define HOEDOWN_EXT_SPAN (\
 	HOEDOWN_EXT_AUTOLINK |\
@@ -51,7 +54,8 @@ typedef enum hoedown_extensions {
 	HOEDOWN_EXT_HIGHLIGHT |\
 	HOEDOWN_EXT_QUOTE |\
 	HOEDOWN_EXT_SUPERSCRIPT |\
-	HOEDOWN_EXT_MATH )
+	HOEDOWN_EXT_MATH |\
+	HOEDOWN_EXT_MATH_BACKTICK)
 
 #define HOEDOWN_EXT_FLAGS (\
 	HOEDOWN_EXT_NO_INTRA_EMPHASIS |\

--- a/test/Tests/BacktickMath.html
+++ b/test/Tests/BacktickMath.html
@@ -1,0 +1,1 @@
+<p>Here is some \(inline math\) using GitLab backtick syntax.</p>

--- a/test/Tests/BacktickMath.text
+++ b/test/Tests/BacktickMath.text
@@ -1,0 +1,2 @@
+Here is some $`inline math`$ using GitLab backtick syntax.
+

--- a/test/Tests/FencedMath.html
+++ b/test/Tests/FencedMath.html
@@ -1,0 +1,4 @@
+<p>Here is some math:</p>
+
+<p>\[\int t dt
+\]</p>

--- a/test/Tests/FencedMath.text
+++ b/test/Tests/FencedMath.text
@@ -1,0 +1,5 @@
+Here is some math:
+
+~~~math
+\int t dt
+~~~

--- a/test/config.json
+++ b/test/config.json
@@ -107,6 +107,16 @@
             "flags": ["--math"]
         },
         {
+            "input": "Tests/FencedMath.text",
+            "output": "Tests/FencedMath.html",
+            "flags": ["--fenced-math"]
+        },
+        {
+            "input": "Tests/BacktickMath.text",
+            "output": "Tests/BacktickMath.html",
+            "flags": ["--backtick-math"]
+        },
+        {
             "input": "Tests/Underline.text",
             "output": "Tests/Underline.html",
             "flags": ["--underline"]


### PR DESCRIPTION
Per MacDownApp/macdown#720.

This supports both $`inline`$ and fenced math style supported by gitlab.

Adds flags HOEDOWN_EXT_FENCED_MATH and HOEDOWN_EXT_MATH_BACKTICK to document.h header and flags --backtick-math and --fenced-math to hoedown executable.
