### PR TITLE
Clumsy attempt to add subscript support

### DIFF
--- a/src/document.h
+++ b/src/document.h
@@ -129,6 +129,7 @@ struct hoedown_renderer {
 	int (*triple_emphasis)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);
 	int (*strikethrough)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);
 	int (*superscript)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);
+	int (*subscript)(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data);
 	int (*footnote_ref)(hoedown_buffer *ob, unsigned int num, const hoedown_renderer_data *data);
 	int (*math)(hoedown_buffer *ob, const hoedown_buffer *text, int displaymode, const hoedown_renderer_data *data);
 	int (*raw_html)(hoedown_buffer *ob, const hoedown_buffer *text, const hoedown_renderer_data *data);

--- a/src/html.c
+++ b/src/html.c
@@ -488,6 +488,16 @@ rndr_superscript(hoedown_buffer *ob, const hoedown_buffer *content, const hoedow
 	return 1;
 }
 
+static int
+rndr_subscript(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data)
+{
+	if (!content || !content->size) return 0;
+	HOEDOWN_BUFPUTSL(ob, "<sub>");
+	hoedown_buffer_put(ob, content->data, content->size);
+	HOEDOWN_BUFPUTSL(ob, "</sub>");
+	return 1;
+}
+
 static void
 rndr_normal_text(hoedown_buffer *ob, const hoedown_buffer *content, const hoedown_renderer_data *data)
 {
@@ -651,6 +661,7 @@ hoedown_html_toc_renderer_new(int nesting_level)
 		rndr_triple_emphasis,
 		rndr_strikethrough,
 		rndr_superscript,
+		rndr_subscript,
 		NULL,
 		NULL,
 		NULL,
@@ -714,6 +725,7 @@ hoedown_html_renderer_new(hoedown_html_flags render_flags, int nesting_level)
 		rndr_triple_emphasis,
 		rndr_strikethrough,
 		rndr_superscript,
+		rndr_subscript,
 		rndr_footnote_ref,
 		rndr_math,
 		rndr_raw_html,


### PR DESCRIPTION
This PR adds support for subscripts, using a tilde notation equivalent to the superscript `^`:
* `N~2` --> N<sub>2</sub>
* `H~(2)O)` --> H<sub>2</sub>O

For now superscripts and subscripts are activated together by the `--superscript` option.

The problem is that `--superscript` now disables `--strikethrough`, which also uses tilde (e.g., `~~foo~~` --> ~foo~).

I'm worthless with C code, so I couldn't find a way to fix `--strikethrough` while preserving subscripts. Any help would be much appreciated, even if it's not merged here (I'd be fine with building my own tweaked version of MacDown for personal use).

